### PR TITLE
Fix bug: Use empty brand name in case of quick add item

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.gmail.marcosav2010'
-version '0.3'
+version '0.4'
 
 subprojects {
     apply plugin: 'java'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.gmail.marcosav2010'
-version '0.4'
+version '0.3.1'
 
 subprojects {
     apply plugin: 'java'

--- a/myfitnesspal-api/src/main/java/com/gmail/marcosav2010/myfitnesspal/api/diary/food/FoodParser.java
+++ b/myfitnesspal-api/src/main/java/com/gmail/marcosav2010/myfitnesspal/api/diary/food/FoodParser.java
@@ -24,7 +24,9 @@ public class FoodParser {
         JSONObject fe = e.getJSONObject("food");
         String id = fe.getString("id");
         String[] desc = fe.getString("description").split(" - ");
-        String brand = fe.getString("brand_name");
+        String brand = "";
+        if (fe.get("brand_ame") != JSONObject.NULL)
+            brand = fe.getString("brand_name");
 
         String name = desc.length > 1 ? desc[1] : desc[0];
 


### PR DESCRIPTION
Hi,

the `FoodParser` throws an exception if the given food is a QuickAdd item, because such items do not contain a brand and `brand_name`'s value is of type `JSONObject` and not `String`.

The fix simply uses an empty brand name in such cases.